### PR TITLE
Twitter以外のモデルにも対応する

### DIFF
--- a/show_tweet.rb
+++ b/show_tweet.rb
@@ -1,27 +1,14 @@
 Plugin.create(:show_tweet) do
-  on_window_created do |i_wnd|
-    @i_main_wnd = i_wnd
-  end
-
-  def main_window
-    Plugin.filtering(:gui_get_gtk_widget, @i_main_wnd).first
-  end
-
   on_show_tweet do |id|
     Thread.new{
       Message.findbyid(id)
-    }.next {|msg|
-      slug = :"show_tweet_#{id}"
-      tab slug, "ツイート" do
-        set_deletable true
-        set_icon Skin.get("list.png")
-        temporary_tab
-        timeline slug
+    }.next{ |messages|
+      if messages.is_a? Enumerable
+        messages = messages.compact
+      else
+        messages = [messages]
       end
-      timeline(slug) << msg
-      timeline(slug).active!
-    }.terminate {|e|
-      activity :error, "ﾂｲｰﾖが取得できませんでした", description: "#{e.to_s}\n#{e.backtrace.join("\n")}"
+      Plugin.call(:open_smartthread, messages)
     }
   end
 
@@ -32,25 +19,22 @@ Plugin.create(:show_tweet) do
     icon: File.join(File.dirname(__FILE__),"show_tweet.png"),
     role: :window) do |opt|
 
-    dlg = Gtk::Dialog.new("ツイートのURL",
-            main_window,
-            Gtk::Dialog::MODAL,
-            [Gtk::Stock::OK, Gtk::Dialog::RESPONSE_OK],
-            [Gtk::Stock::CANCEL, Gtk::Dialog::RESPONSE_CANCEL])
-    begin
-      entry = Gtk::Entry.new
-      dlg.vbox.add(entry)
-      dlg.show_all
-
-      if dlg.run == Gtk::Dialog::RESPONSE_OK
-        url = entry.text
-        # Be robust ;)
-        if m = url.match(/\d+$/)
-          Plugin.call(:show_tweet, m[0].to_i)
-        end
-      end
-    ensure
-      dlg.destroy
+    dialog "ツイートのURL" do
+      input "URL", :url
+    end.next do |result|
+      url = Diva::URI.new(result[:url])
+      model_class = Enumerator.new{ |y|
+        Plugin.filtering(:model_of_uri, url, y)
+      }.lazy.map{ |model_slug|
+        Diva::Model(model_slug)
+      }.find{ |mc|
+        mc.spec.timeline
+      }
+      Delayer.Deferred.new{
+        model_class.find_by_uri(url)
+      }.next{ |message|
+        Plugin.call(:open_smartthread, [message])
+      }
     end
   end
 end


### PR DESCRIPTION
以下の修正（？）をするリクエストです。3番目がメインです。
* ダイアログ表示時の不安定性をdialog DSLへ移行することで回避
* ツイート表示機能をsmartthreadへ移譲
* ツイートに限らずあらゆるModelをhandleで取得して表示できるように修正

ほとんど原型を留めなくなってしまったのでアレですが、インターフェイスやイベント名は維持しています。
